### PR TITLE
Render blank tile with placeholder

### DIFF
--- a/TEST_PLAN.md
+++ b/TEST_PLAN.md
@@ -6,8 +6,8 @@
 - [ ] Load landscape image – should crop to square.
 
 ## Tile Display
-- [ ] Check that 15 tiles are visible and correctly spaced.
-- [ ] Ensure bottom-right tile is empty.
+- [ ] Check that 15 picture tiles plus one blank tile are visible and correctly spaced.
+- [ ] Ensure bottom-right tile shows a gray placeholder tile instead of empty space.
 
 ## Tile Movement
 - [ ] Click to move adjacent tile – should slide.

--- a/main.py
+++ b/main.py
@@ -1,7 +1,7 @@
 import os
 import tkinter as tk
 from tkinter import filedialog, messagebox
-from PIL import ImageTk
+from PIL import ImageTk, Image, ImageDraw
 
 import image_utils
 from puzzle_logic import Puzzle
@@ -22,6 +22,7 @@ class PuzzleGUI:
         self.puzzle = Puzzle(GRID_SIZE)
         self.tile_imgs = []
         self.buttons = []
+        self.empty_img = self._create_empty_tile()
         self.move_label = tk.Label(root, text="Moves: 0")
         self.move_label.pack()
         self.board = tk.Frame(root, width=WINDOW_SIZE, height=WINDOW_SIZE)
@@ -38,6 +39,13 @@ class PuzzleGUI:
         file_menu.add_command(label="Open Image", command=self.load_image)
         file_menu.add_separator()
         file_menu.add_command(label="Exit", command=self.root.quit)
+
+    def _create_empty_tile(self) -> ImageTk.PhotoImage:
+        """Return a placeholder image for the blank tile."""
+        img = Image.new("RGB", (TILE_SIZE, TILE_SIZE), "white")
+        draw = ImageDraw.Draw(img)
+        draw.rectangle((0, 0, TILE_SIZE - 1, TILE_SIZE - 1), outline="gray")
+        return ImageTk.PhotoImage(img)
 
     def load_image(self) -> None:
         path = filedialog.askopenfilename(
@@ -56,15 +64,18 @@ class PuzzleGUI:
                 btn.destroy()
             self.buttons.clear()
         for i in range(GRID_SIZE ** 2):
+            img = (
+                self.tile_imgs[self.puzzle.tiles[i]]
+                if self.puzzle.tiles[i] != self.puzzle.blank
+                else self.empty_img
+            )
             btn = tk.Button(
                 self.board,
                 command=lambda idx=i: self.on_click(idx),
-                width=TILE_SIZE,
-                height=TILE_SIZE,
-                image=self.tile_imgs[self.puzzle.tiles[i]]
-                if self.puzzle.tiles[i] != self.puzzle.blank
-                else None,
+                image=img,
             )
+            if self.puzzle.tiles[i] == self.puzzle.blank:
+                btn.config(state=tk.DISABLED)
             btn.grid(row=i // GRID_SIZE, column=i % GRID_SIZE)
             self.buttons.append(btn)
         self.update_board()
@@ -73,9 +84,9 @@ class PuzzleGUI:
         for i, btn in enumerate(self.buttons):
             tile_index = self.puzzle.tiles[i]
             if tile_index == self.puzzle.blank:
-                btn.config(image="", text="")
+                btn.config(image=self.empty_img, state=tk.DISABLED)
             else:
-                btn.config(image=self.tile_imgs[tile_index])
+                btn.config(image=self.tile_imgs[tile_index], state=tk.NORMAL)
         self.move_label.config(text=f"Moves: {self.puzzle.moves}")
         if self.puzzle.is_solved():
             messagebox.showinfo("Puzzle", "Congratulations! You solved it!")


### PR DESCRIPTION
## Summary
- show blank tile using a solid placeholder image
- disable interaction with the blank tile
- update test plan to mention the new grey tile

## Testing
- `python -m py_compile main.py puzzle_logic.py image_utils.py`

------
https://chatgpt.com/codex/tasks/task_b_684c50c7124c8329b09f2a6c7bbbd53b